### PR TITLE
Fix piece hover and color update

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <!-- Page principale du jeu Puissance 4 -->
     <div class="container">
         <h1>Puissance 4</h1>
-        <canvas id="gameCanvas" width="700" height="600"></canvas>
+        <canvas id="gameCanvas" width="700" height="700"></canvas>
         <div class="controls">
             <button id="resetButton">Nouvelle partie</button>
             <button id="darkModeToggle">Mode sombre</button>

--- a/script.js
+++ b/script.js
@@ -142,17 +142,17 @@ class Puissance4 {
         for (let row = this.ROWS - 1; row >= 0; row--) {
             if (this.board[row][col] === 0) {
                 this.board[row][col] = this.currentPlayer;
-                this.drawBoard();
 
                 if (this.checkWin(row, col)) {
                     this.gameOver = true;
+                    this.drawBoard();
                     this.statusDisplay.textContent = `Joueur ${this.currentPlayer} a gagné !`;
-                    return;
+                } else {
+                    // Passage au joueur suivant
+                    this.currentPlayer = this.currentPlayer === 1 ? 2 : 1;
+                    this.statusDisplay.textContent = `Tour du joueur ${this.currentPlayer}`;
+                    this.drawBoard();
                 }
-
-                // Passage au joueur suivant
-                this.currentPlayer = this.currentPlayer === 1 ? 2 : 1;
-                this.statusDisplay.textContent = `Tour du joueur ${this.currentPlayer}`;
                 return;
             }
         }


### PR DESCRIPTION
## Summary
- enlarge the canvas to provide room for the preview pawn
- update `dropPiece` to redraw the board after switching players so the preview pawn uses the right colour

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a224027e8832ba790bf75c25f61b9