### PR TITLE
Fix hover piece persisting after win, add score placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <div class="container">
         <h1>Puissance 4</h1>
         <canvas id="gameCanvas" width="700" height="700"></canvas>
+        <div id="score">Score - Joueur 1: 0 | Joueur 2: 0</div>
         <div class="controls">
             <button id="resetButton">Nouvelle partie</button>
             <button id="darkModeToggle">Mode sombre</button>

--- a/script.js
+++ b/script.js
@@ -117,6 +117,7 @@ class Puissance4 {
 
     // Affiche un pion temporaire lors du survol d'une colonne disponible
     handleMouseMove(e) {
+        if (this.gameOver) return;
         const rect = this.canvas.getBoundingClientRect();
         const x = e.clientX - rect.left - this.offsetX - this.PADDING;
         const col = Math.floor(x / (this.CELL_SIZE + this.PADDING));
@@ -145,6 +146,7 @@ class Puissance4 {
 
                 if (this.checkWin(row, col)) {
                     this.gameOver = true;
+                    this.hoverCol = null;
                     this.drawBoard();
                     this.statusDisplay.textContent = `Joueur ${this.currentPlayer} a gagné !`;
                 } else {

--- a/style.css
+++ b/style.css
@@ -91,3 +91,15 @@ body.dark-mode #status {
 #darkModeToggle:hover {
     background-color: #555;
 }
+
+/* Zone d'affichage du score */
+#score {
+    margin-top: 0.5rem;
+    font-size: 1rem;
+    font-weight: bold;
+    color: #333;
+}
+
+body.dark-mode #score {
+    color: #eee;
+}


### PR DESCRIPTION
## Summary
- hide ghost piece when the game ends
- avoid showing hover piece once game is over
- prepare a score area under the game board

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a23b9bed8832b9af62bddcf183c31