### PR TITLE
Add moon/sun dark mode button

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Ce projet contient une implémentation basique du jeu **Puissance 4** réalisée
 
 Ouvrez simplement `index.html` dans un navigateur pour lancer une partie.
 
-Vous pouvez activer un **mode sombre** grâce au bouton "Mode sombre" présent sur la page.
+Vous pouvez activer un **mode sombre** grâce au bouton représenté par une icône de lune ou de soleil situé en haut à droite de la page.

--- a/index.html
+++ b/index.html
@@ -19,11 +19,11 @@
 
     <!-- Page principale du jeu Puissance 4 -->
     <div class="container hidden">
+        <button id="darkModeToggle" class="dark-mode-btn" title="Basculer le mode sombre">🌙</button>
         <h1>Puissance 4</h1>
         <canvas id="gameCanvas" width="700" height="700"></canvas>
         <div class="controls">
             <button id="resetButton">Nouvelle partie</button>
-            <button id="darkModeToggle">Mode sombre</button>
         </div>
     </div>
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -278,9 +278,11 @@ class Puissance4 {
     toggleDarkMode() {
         document.body.classList.toggle('dark-mode');
         if (document.body.classList.contains('dark-mode')) {
-            this.darkModeToggle.textContent = 'Mode clair';
+            this.darkModeToggle.textContent = '☀️';
+            this.darkModeToggle.title = 'Mode clair';
         } else {
-            this.darkModeToggle.textContent = 'Mode sombre';
+            this.darkModeToggle.textContent = '🌙';
+            this.darkModeToggle.title = 'Mode sombre';
         }
     }
 }

--- a/style.css
+++ b/style.css
@@ -19,6 +19,7 @@ body.dark-mode {
 }
 
 .container {
+    position: relative;
     text-align: center;
     background-color: white;
     padding: 2rem;
@@ -81,18 +82,19 @@ body.dark-mode #status {
 */
 
 #darkModeToggle {
-    padding: 0.5rem 1rem;
-    font-size: 1rem;
-    background-color: #333;
-    color: white;
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    background: none;
     border: none;
-    border-radius: 5px;
+    font-size: 1.5rem;
     cursor: pointer;
-    transition: background-color 0.3s;
+    color: #333;
+    transition: color 0.3s;
 }
 
-#darkModeToggle:hover {
-    background-color: #555;
+body.dark-mode #darkModeToggle {
+    color: #eee;
 }
 
 


### PR DESCRIPTION
## Summary
- add dark mode toggle button with moon and sun icons
- position dark mode toggle at the top-right of the game container
- update script to switch icons when toggling
- update documentation to mention new button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a32494b10832bbf8efdaed366c554