### PR TITLE
Add victory and draw sounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,6 @@
 Ce projet contient une implémentation basique du jeu **Puissance 4** réalisée avec HTML5, CSS et JavaScript. L'interface repose sur un canvas pour dessiner le plateau et toutes les interactions se font côté client.
 
 Ouvrez simplement `index.html` dans un navigateur pour lancer une partie. Un court son est joué à chaque fois qu'un pion est placé.
+Des effets sonores signalent désormais la victoire ou un match nul pour rendre la fin de partie plus claire.
 
 Vous pouvez activer un **mode sombre** grâce au bouton représenté par une icône de lune ou de soleil situé en haut à droite de la page.

--- a/script.js
+++ b/script.js
@@ -132,6 +132,40 @@ class Puissance4 {
         osc.stop(ctx.currentTime + 0.2);
     }
 
+    // Joue un son bref pour signaler la victoire d'un joueur
+    playWinSound() {
+        if (!this.audioCtx) {
+            this.audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+        }
+        const ctx = this.audioCtx;
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = "sawtooth";
+        osc.frequency.setValueAtTime(880, ctx.currentTime);
+        gain.gain.setValueAtTime(0.4, ctx.currentTime);
+        osc.connect(gain);
+        gain.connect(ctx.destination);
+        osc.start();
+        osc.stop(ctx.currentTime + 0.4);
+    }
+
+    // Joue un son lorsque la partie se termine sur un match nul
+    playDrawSound() {
+        if (!this.audioCtx) {
+            this.audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+        }
+        const ctx = this.audioCtx;
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = "triangle";
+        osc.frequency.setValueAtTime(300, ctx.currentTime);
+        gain.gain.setValueAtTime(0.3, ctx.currentTime);
+        osc.connect(gain);
+        gain.connect(ctx.destination);
+        osc.start();
+        osc.stop(ctx.currentTime + 0.3);
+    }
+
     // Dessine le plateau et les pions dans le canvas
     drawBoard() {
         this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
@@ -239,6 +273,7 @@ class Puissance4 {
                     this.hoverCol = null;
                     // La partie est finie : activer le bouton de nouvelle partie
                     this.resetButton.disabled = false;
+                    this.playWinSound();
                     const winnerName =
                         this.currentPlayer === 1
                             ? this.player1Name
@@ -251,6 +286,7 @@ class Puissance4 {
                     this.gameOver = true;
                     this.hoverCol = null;
                     this.resetButton.disabled = false;
+                    this.playDrawSound();
                     this.statusText = "Match nul !";
                     this.statusColor = "green";
                 } else {


### PR DESCRIPTION
## Summary
- play a short sound when a win occurs
- play a sound when the game ends in a draw
- document the new end-game sounds

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a37c5e3ac832b90b299c2207dd192