### PR TITLE
Add outline around canvas status text

### DIFF
--- a/script.js
+++ b/script.js
@@ -54,6 +54,9 @@ class Puissance4 {
         // Couleur du texte selon l'état courant
         this.ctx.fillStyle = this.statusColor;
         this.ctx.fillText(this.statusText, this.canvas.width / 2, y);
+        this.ctx.lineWidth = 3;
+        this.ctx.strokeStyle = "white";
+        this.ctx.strokeText(this.statusText, this.canvas.width / 2, y);
         this.ctx.restore();
     }
 
@@ -71,11 +74,25 @@ class Puissance4 {
             20,
             this.canvas.height - 10
         );
+        this.ctx.lineWidth = 2;
+        this.ctx.strokeStyle = "white";
+        this.ctx.strokeText(
+            `${this.player1Name}: ${this.scores[0]}`,
+            20,
+            this.canvas.height - 10
+        );
 
         // Score du joueur 2 en bas à droite
         this.ctx.textAlign = "right";
         this.ctx.fillStyle = "yellow";
         this.ctx.fillText(
+            `${this.player2Name}: ${this.scores[1]}`,
+            this.canvas.width - 20,
+            this.canvas.height - 10
+        );
+        this.ctx.lineWidth = 2;
+        this.ctx.strokeStyle = "white";
+        this.ctx.strokeText(
             `${this.player2Name}: ${this.scores[1]}`,
             this.canvas.width - 20,
             this.canvas.height - 10


### PR DESCRIPTION
## Summary
- outline status text in white
- outline score text in white

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a396eb798832bbff4a7e0e97904ac