### PR TITLE
Add helper methods for cell coordinates

### DIFF
--- a/script.js
+++ b/script.js
@@ -103,6 +103,17 @@ class Puissance4 {
         this.offsetY = (this.canvas.height - boardHeight) / 2;
     }
 
+    // Helpers pour calculer les positions des cases
+    // Renvoie la coordonnée X du coin supérieur gauche d'une colonne
+    getCellX(col) {
+        return this.offsetX + this.PADDING + col * (this.CELL_SIZE + this.PADDING);
+    }
+
+    // Renvoie la coordonnée Y du coin supérieur gauche d'une ligne
+    getCellY(row) {
+        return this.offsetY + this.PADDING + row * (this.CELL_SIZE + this.PADDING);
+    }
+
     // Initialise les écouteurs et dessine le plateau vide
     init() {
         this.drawBoard();
@@ -184,14 +195,8 @@ class Puissance4 {
 
         for (let row = 0; row < this.ROWS; row++) {
             for (let col = 0; col < this.COLS; col++) {
-                const x =
-                    this.offsetX +
-                    this.PADDING +
-                    col * (this.CELL_SIZE + this.PADDING);
-                const y =
-                    this.offsetY +
-                    this.PADDING +
-                    row * (this.CELL_SIZE + this.PADDING);
+                const x = this.getCellX(col);
+                const y = this.getCellY(row);
 
                 // Cercle représentant l'emplacement du pion
                 this.ctx.beginPath();
@@ -218,11 +223,7 @@ class Puissance4 {
         }
 
         if (this.hoverCol !== null) {
-            const x =
-                this.offsetX +
-                this.PADDING +
-                this.hoverCol * (this.CELL_SIZE + this.PADDING) +
-                this.CELL_SIZE / 2;
+            const x = this.getCellX(this.hoverCol) + this.CELL_SIZE / 2;
             const y = this.offsetY + this.PADDING - this.CELL_SIZE / 2;
 
             this.ctx.beginPath();
@@ -254,7 +255,7 @@ class Puissance4 {
     handleMouseMove(e) {
         if (this.gameOver || this.animating) return;
         const rect = this.canvas.getBoundingClientRect();
-        const x = e.clientX - rect.left - this.offsetX - this.PADDING;
+        const x = e.clientX - rect.left - this.getCellX(0);
         const col = Math.floor(x / (this.CELL_SIZE + this.PADDING));
         const maxX = this.COLS * (this.CELL_SIZE + this.PADDING) - this.PADDING;
 
@@ -329,16 +330,8 @@ class Puissance4 {
 
     animateDrop(col, targetRow, done) {
         let y = this.offsetY + this.PADDING - this.CELL_SIZE / 2;
-        const finalY =
-            this.offsetY +
-            this.PADDING +
-            targetRow * (this.CELL_SIZE + this.PADDING) +
-            this.CELL_SIZE / 2;
-        const x =
-            this.offsetX +
-            this.PADDING +
-            col * (this.CELL_SIZE + this.PADDING) +
-            this.CELL_SIZE / 2;
+        const finalY = this.getCellY(targetRow) + this.CELL_SIZE / 2;
+        const x = this.getCellX(col) + this.CELL_SIZE / 2;
         const step = () => {
             this.drawBoard();
             this.ctx.beginPath();


### PR DESCRIPTION
## Summary
- add `getCellX` and `getCellY` helpers in `script.js`
- use helpers in board drawing, mouse hover logic and drop animation
- document helper utilities

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684a4067a608832bae14f47cd7963585